### PR TITLE
Updated for XCCDF/OVAL WG issue #8: Improved support for remediation …

### DIFF
--- a/markdown/xccdf.md
+++ b/markdown/xccdf.md
@@ -850,7 +850,7 @@ An _\<xccdf:Rule\>_ element defines a single item to be checked as part of a ben
 The example below shows a very simple _\<xccdf:Rule\>_ element.
 
 | \<xccdf:Rule id="xccdf\_org.example\_rule\_pwd-perm" selected="1" weight="6.5" severity="high"\>\<xccdf:title\>Password File Permission\</xccdf:title\>\<xccdf:description\>Check the access control on the password file. Normal users should not be able to write to it.
- \</xccdf:description\>\<xccdf:requires idref="xccdf\_org.example\_rule\_passwd-exists"/\>\<xccdf:fixtext\>Set permissions on the passwd file to owner-write, world-read\</xccdf:fixtext\>\<xccdf:fix strategy="restrict" reboot="0" disruption="low"\>chmod 644 /etc/passwd\</xccdf:fix\>\<xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5"\>\<xccdf:check-content-ref href="ovaldefs.xml" name="oval:org.example:def:123"/\>\</xccdf:check\>\</xccdf:Rule\> |
+ \</xccdf:description\>\<xccdf:requires idref="xccdf\_org.example\_rule\_passwd-exists"/\>\<xccdf:fixtext\>Set permissions on the passwd file to owner-write, world-read\</xccdf:fixtext\>\<xccdf:fix strategy="restrict" reboot="0" disruption="low" system="urn:xccdf:fix:commands"\>\<xccdf:fix-content\>chmod 644 /etc/passwd\\</xccdf:fix-content\></xccdf:fix\>\<xccdf:check system="http://oval.mitre.org/XMLSchema/oval-definitions-5"\>\<xccdf:check-content-ref href="ovaldefs.xml" name="oval:org.example:def:123"/\>\</xccdf:check\>\</xccdf:Rule\> |
 | --- |
 
 One of XCCDF's main features is the organization and selection of target-applicable groups and rules for performing security and operational checks on systems. XCCDF can access granular and expressive mechanisms for assessing the state of a system according to the rule criteria. Examples of these mechanisms are definitions expressed in the Open Vulnerability and Assessment Language (OVAL) and questionnaires expressed in the Open Checklist Interactive Language (OCIL). These checking mechanisms follow the conceptual model of collecting or acquiring the state of a target system, and then assessing the state for conformance to conditions and criteria expressed as rules.
@@ -1037,6 +1037,17 @@ Table 16 lists the possible properties of an _\<xccdf:fix\>_ element.
 | complexity (attribute)    | string     | 0-1   | The estimated complexity or difficulty of applying the fix to the target.See Table 15 for the list of possible values. |
 | system (attribute)        | URI        | 0-1   | A URI that identifies the scheme, language, engine, or process for which the fix contents are written. Table 17 defines several general-purpose URNs that may be used for this, and tool vendors and system providers may define and use target-specific URNs. |
 | platform (attribute)      | URI        | 0-1   | In case different fix scripts or procedures are required for different target platform types (e.g., different patches for Windows Vista and Windows 7), this attribute allows a CPE name or CPE applicability language expression to be associated with an _\<xccdf:fix\>_element. This should appear on an _\<xccdf:fix\>_ when the content applies to only one platform out of several to which the rule could apply. |
+
+
+Table 16a lists the possible properties of an _\<xccdf:fix-content\>_ element
+
+**Table 16a: Possible Properties for \<xccdf:fix-content\> Element**
+
+| Property                  | Type       | Count | Description |
+| ------------------------- | ---------- | ----- | ----------- |
+| sub (element)             | identifier | 0-n   | Specifies an _\<xccdf:Value\>_ or _\<xccdf:plain-text\>_ substitution. See Section 6.2.9. |
+| instance (element)        | string     | 0-n   | Designates a spot where the name of the instance should be substituted into the fix template to generate the final fix data. If the _@__context_ attribute is omitted, the value of the context shalldefault to "undefined". |
+
 
 Table 17lists predefined values for the _@s __ystem_attribute of an_\<xccdf:__ fix__\>_ element.
 

--- a/markdown/xccdf.md
+++ b/markdown/xccdf.md
@@ -1024,18 +1024,19 @@ Table 16 lists the possible properties of an _\<xccdf:fix\>_ element.
 
 **Table 16: Possible Properties for \<xccdf:fix\> Element**
 
-| Property | Type | Count | Description |
-| --- | --- | --- | --- |
-| sub (element) | identifier | 0-n | Specifies an _\<xccdf:Value\>_ or _\<xccdf:plain-text\>_ substitution. See Section 6.2.9. |
-| --- | --- | --- | --- |
-| instance (element) | string | Designates a spot where the name of the instance should be substituted into the fix template to generate the final fix data. If the _@__context_ attribute is omitted, the value of the context shalldefault to "undefined". |
-| id (attribute) | identifier | 0-1 | A local identifier for the element. It is optional for the id to be unique; multiple_\<xccdf:fix\>_ elements may have the same id but different values for their other attributes. |
-| reboot (attribute) | boolean | 0-1 | Whether or not remediation will require a reboot or hard reset of the target. Permitted values: true (1) and false (0) (default: 0). |
-| strategy (attribute) | string | 0-1 | The method or approach for fixing the problem. See Table 15 for the list of possible values. |
-| disruption (attribute) | string | 0-1 | An estimate of the potential for disruption or operational degradation that the application of this fix will impose on the target.See Table 15 for the list of possible values. |
-| complexity (attribute) | string | 0-1 | The estimated complexity or difficulty of applying the fix to the target.See Table 15 for the list of possible values. |
-| system (attribute) | URI | 0-1 | A URI that identifies the scheme, language, engine, or process for which the fix contents are written. Table 17 defines several general-purpose URNs that may be used for this, and tool vendors and system providers may define and use target-specific URNs. |
-| platform (attribute) | URI | 0-1 | In case different fix scripts or procedures are required for different target platform types (e.g., different patches for Windows Vista and Windows 7), this attribute allows a CPE name or CPE applicability language expression to be associated with an _\<xccdf:fix\>_element. This should appear on an _\<xccdf:fix\>_ when the content applies to only one platform out of several to which the rule could apply. |
+| Property                  | Type       | Count | Description |
+| ------------------------- | ---------- | ----- | ----------- |
+| fix-export (element)      | _special_  | 0-n   | A mapping from an _\<xccdf:Value\>_ element to a fix system variable (i.e., external name or id for use by the checking system). This supports export of tailoring values from the XCCDF processing environment to the fix system.|
+| fix-content-ref (element) | _special_  | 0-n   | Points to code for a detached fix in another location that uses the language or system specified by the _\<xccdf:fix\>_ element’s `@system` attribute. If multiple _\<xccdf:fix-content-ref\>_ elements appear, they represent alternative locations from which a benchmark consumer may obtain the fix content. Benchmark consumers should process the alternatives in the order in which they appear in the XML. The first _\<xccdf:fix-content-ref\>_ from which content can be successfully retrieved should be used. |
+| fix-content (element)     | _special_  | 0-n   | Holds the actual code of a fix, in the language or system specified by the _\<xccdf:fix\>_ element’s `@system` attribute. If both _\<xccdf:fix-content-ref\>_ and _\<xccdf:fix-content\>_ elements appear in a single _\<xccdf:fix\>_ element, benchmark consumers should use the _\<xccdf:fix-content\>_ element only if none of the references can be resolved to provide content. |
+| ------                    | ----       | ----- | ----------- |
+| id (attribute)            | identifier | 0-1   | A local identifier for the element. It is optional for the id to be unique; multiple_\<xccdf:fix\>_ elements may have the same id but different values for their other attributes. |
+| reboot (attribute)        | boolean    | 0-1   | Whether or not remediation will require a reboot or hard reset of the target. Permitted values: true (1) and false (0) (default: 0). |
+| strategy (attribute)      | string     | 0-1   | The method or approach for fixing the problem. See Table 15 for the list of possible values. |
+| disruption (attribute)    | string     | 0-1   | An estimate of the potential for disruption or operational degradation that the application of this fix will impose on the target.See Table 15 for the list of possible values. |
+| complexity (attribute)    | string     | 0-1   | The estimated complexity or difficulty of applying the fix to the target.See Table 15 for the list of possible values. |
+| system (attribute)        | URI        | 0-1   | A URI that identifies the scheme, language, engine, or process for which the fix contents are written. Table 17 defines several general-purpose URNs that may be used for this, and tool vendors and system providers may define and use target-specific URNs. |
+| platform (attribute)      | URI        | 0-1   | In case different fix scripts or procedures are required for different target platform types (e.g., different patches for Windows Vista and Windows 7), this attribute allows a CPE name or CPE applicability language expression to be associated with an _\<xccdf:fix\>_element. This should appear on an _\<xccdf:fix\>_ when the content applies to only one platform out of several to which the rule could apply. |
 
 Table 17lists predefined values for the _@s __ystem_attribute of an_\<xccdf:__ fix__\>_ element.
 

--- a/xccdf.xsd
+++ b/xccdf.xsd
@@ -1557,30 +1557,48 @@
         </xsd:complexContent>
     </xsd:complexType>
 
-    <xsd:complexType name="fixType" mixed="true">
+    <xsd:complexType name="fixType"> <!-- PROPOSED: REMOVED 'mixed="true"' -->
         <xsd:annotation>
             <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fix&gt; element. The body
                 of this element contains a command string, script, or other system modification
                 statement that, if executed on the target system, can bring it into full, or at
                 least better, compliance with this &lt;xccdf:Rule&gt;. </xsd:documentation>
         </xsd:annotation>
-        <xsd:choice minOccurs="0" maxOccurs="unbounded">
-            <xsd:element name="sub" type="cdf:subType">
+        <!-- PROPOSED -->
+        <xsd:sequence>
+            <xsd:element name="fix-export" type="cdf:fixExportType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
-                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
-                        &lt;xccdf:plain-text&gt; element to be used for text substitution
-                    </xsd:documentation>
+                    <xsd:documentation xml:lang="en">A mapping from an &lt;xccdf:Value&gt; element
+                        to a fix system variable (i.e., external name or id for use by the
+                        checking system). This supports export of tailoring values from the XCCDF
+                        processing environment to the fix system.</xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-            <xsd:element name="instance" type="cdf:instanceFixType">
+            <xsd:element name="fix-content-ref" type="cdf:fixContentRefType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
-                    <xsd:documentation xml:lang="en">Designates a spot where the name of the
-                        instance should be substituted into the fix template to generate the final
-                        fix data. If the @context attribute is omitted, the value of the @context
-                        defaults to “undefined”.</xsd:documentation>
+                    <xsd:documentation xml:lang="en">Points to code for a detached fix in another
+                        location that uses the language or system specified by the
+                        &lt;xccdf:fix&gt; element’s @system attribute. If multiple
+                        &lt;xccdf:fix-content-ref&gt; elements appear, they represent alternative
+                        locations from which a benchmark consumer may obtain the fix content.
+                        Benchmark consumers should process the alternatives in the order in which
+                        they appear in the XML. The first &lt;xccdf:fix-content-ref&gt; from which
+                        content can be successfully retrieved should be used.</xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
-        </xsd:choice>
+            <xsd:element name="fix-content" type="cdf:fixContentType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds the actual code of a fix, in the
+                        language or system specified by the &lt;xccdf:fix&gt; element’s @system
+                        attribute. If both &lt;xccdf:fix-content-ref&gt; and
+                        &lt;xccdf:fix-content&gt; elements appear in a single &lt;xccdf:fix&gt;
+                        element, benchmark consumers should use the &lt;xccdf:fix-content&gt;
+                        element only if none of the references can be resolved to provide
+                        content.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <!-- /PROPOSED -->
         <xsd:attribute name="id" type="xsd:NCName" use="optional">
             <xsd:annotation>
                 <xsd:documentation xml:lang="en">A local identifier for the element. It is optional
@@ -1637,7 +1655,94 @@
             </xsd:annotation>
         </xsd:attribute>
     </xsd:complexType>
-
+    
+    <!-- PROPOSED -->
+    <xsd:complexType name="fixExportType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fix-export&gt; element,
+                which specifies a mapping from an &lt;xccdf:Value&gt; element to a remediation system
+                variable (i.e., external name or id for use by the fix system). This supports
+                export of tailoring &lt;xccdf:Value&gt; elements from the XCCDF processing
+                environment to the fix system. The interface between the XCCDF benchmark
+                consumer and the fix system should support, at a minimum, passing the
+                &lt;xccdf:value&gt; property of the &lt;xccdf:Value&gt; element, but may also
+                support passing the &lt;xccdf:Value&gt; element's @type and @operator
+                properties.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="value-id" type="xsd:NCName" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The id of the &lt;xccdf:Value&gt; element to export.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="export-name" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">An identifier indicating some structure in the
+                    fix system into which the identified &lt;xccdf:Value&gt; element's
+                    properties will be mapped. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    
+    <xsd:complexType name="fixContentRefType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fix-content-ref&gt;
+                element, which points to the code for a detached fix in another file. This element
+                has no body, just a number of attributes: @href, @name, and @media-type. The @name is optional, if
+                it does not appear then this reference is to the entire document. The @media-type is optional as well, 
+                only applicable when the @href value points to a compressed file.
+            </xsd:documentation>
+        </xsd:annotation>
+        <xsd:attribute name="href" type="xsd:anyURI" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Identifies the referenced document containing
+                    fix instructions. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="name" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">Identifies a particular part or element of the
+                    referenced fix document. </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="media-type" type="xsd:string">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">
+                    Applicable in cases where &lt;xccdf:fix-content-ref&gt; is used and the @href 
+                    attribute points to a compressed file.
+                </xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    
+    <xsd:complexType name="fixContentType" mixed="true">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:fix-content&gt; element.
+                The body of this element holds the actual code of a fix, in the language or system
+                specified by the &lt;xccdf:fix&gt; element’s @system attribute. The body of this
+                element may be any content, but cannot contain any XCCDF elements. XCCDF tools do not
+                process its content directly but instead pass the content directly to fixing/remediation
+                engines. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice minOccurs="0" maxOccurs="unbounded">
+            <xsd:element name="sub" type="cdf:subType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Specifies an &lt;xccdf:Value&gt; or
+                        &lt;xccdf:plain-text&gt; element to be used for text substitution
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="instance" type="cdf:instanceFixType">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Designates a spot where the name of the
+                        instance should be substituted into the fix template to generate the final
+                        fix data. If the @context attribute is omitted, the value of the @context
+                        defaults to “undefined”.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:complexType>
+    <!-- /PROPOSED -->
+    
     <xsd:simpleType name="fixStrategyEnumType">
         <xsd:annotation>
             <xsd:documentation xml:lang="en"> Allowed @strategy keyword values for an

--- a/xccdf.xsd
+++ b/xccdf.xsd
@@ -1571,7 +1571,9 @@
                     <xsd:documentation xml:lang="en">A mapping from an &lt;xccdf:Value&gt; element
                         to a fix system variable (i.e., external name or id for use by the
                         checking system). This supports export of tailoring values from the XCCDF
-                        processing environment to the fix system.</xsd:documentation>
+                        processing environment to the fix system.  The fix-export is analogous to the
+                        &lt;xccdf:check-export&gt; allowing XCCDF Values to be passed to the external 
+                        content referenced by a &lt;xccdf:fix-content-ref&gt;</xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
             <xsd:element name="fix-content-ref" type="cdf:fixContentRefType" minOccurs="0" maxOccurs="unbounded">


### PR DESCRIPTION
Updated for XCCDF/OVAL WG issue #8: Improved support for remediation …

Wrapped changes around comments labeled `PROPOSED` and `/PROPOSED`