### PR TITLE
Adding schema support for the changelog element

### DIFF
--- a/markdown/xccdf.md
+++ b/markdown/xccdf.md
@@ -610,8 +610,8 @@ Elements that support the _\<xccdf:metadata\>_ element MAY use any desired metad
 
 Metadata is a powerful feature for authors. However, XCCDF puts some limits on the use of metadata:
 
-- Metadata shOULD not replace the functionality of existing fields within XCCDF. If the information matches the common use of some other XCCDF field, the information must appear in that XCCDF field. It MAY also appear in the _\<xccdf:metadata\>_ element.
-- Metadata shall not change the processing model as outlined in Section 7. Benchmark consumer products shall perform XCCDF assessments in the same way regardless of the presence of metadata. Metadata may still be used to support assessment features that are outside the purview of XCCDF—for example, to hold post-processing instructions to be performed on the completed XCCDF resultsor to display additional information to the user before or during the assessment.
+- Metadata SHOULD not replace the functionality of existing fields within XCCDF. If the information matches the common use of some other XCCDF field, the information must appear in that XCCDF field. It MAY also appear in the _\<xccdf:metadata\>_ element.
+- Metadata shall not change the processing model as outlined in Section 7. Benchmark consumer products shall perform XCCDF assessments in the same way regardless of the presence of metadata. Metadata may still be used to support assessment features that are outside the purview of XCCDF—for example, to hold post-processing instructions to be performed on the completed XCCDF results or to display additional information to the user before or during the assessment.
 - Metadata SHOULD not alter the character content of the XCCDF properties used to generate output during document generation. Contents of the _\<xccdf:metadata\>_ element MAY be added to the output above and beyond the XCCDF properties. Metadata may contain instructions that cause different stylistic conventions to be adopted in the conversion of an XCCDF document to prose.
 
 ### 6.2.5Platform Names

--- a/xccdf.xsd
+++ b/xccdf.xsd
@@ -987,6 +987,12 @@
                     </xsd:documentation>
                 </xsd:annotation>
             </xsd:element>
+            <xsd:element name="changelog" type="cdf:changeLogType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Holds the change history of the item.
+                    </xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
             <xsd:element name="title" type="cdf:textWithSubType" minOccurs="0" maxOccurs="unbounded">
                 <xsd:annotation>
                     <xsd:documentation xml:lang="en">Title of the item. Every item should have an
@@ -2076,6 +2082,87 @@ NOT || P | F | U | E | N | K | S | I ||
             <xsd:any namespace="##other" processContents="skip"/>
         </xsd:choice>
     </xsd:complexType>
+
+    <xsd:complexType name="changeLogType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en">Data type for the &lt;xccdf:changelog&gt; element, 
+                which provides the change history of the item.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="change" type="cdf:changeType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">An entry in the &lt;changelog&gt; that documents the
+                        changes made to the item.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:complexType name="changeType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Data type for the &lt;xccdf:change&gt; element that
+                represents a specific &lt;xccdf:change&gt; in the &lt;xccdf:changelog&gt; element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="description" type="xsd:string" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">Text that describes the change.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="version" type="xsd:string" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The version number of the item.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="time" type="xsd:dateTime" use="optional">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The time when the version that this change
+                    was completed in the UTC ISO 8601 format.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+        <xsd:attribute name="action" type="cdf:actionEnumType" use="required">
+            <xsd:annotation>
+                <xsd:documentation xml:lang="en">The action that describes the change.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    
+    <xsd:simpleType name="actionEnumType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="en"> Allowed @action keyword values for an
+                &lt;xccdf:change&gt; element. </xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="created">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The item has been created.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="revised">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The item has been revised in a way that
+                        does not constitute a significant change (e.g., the removal of an obvious
+                        typo that did not lead to misinterpretations of the item, and added clarification, 
+                        etc.)</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="modified">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The item has been revised in a way that
+                        constitutes a significant change.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="removed">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="en">The item has been removed (e.g., by setting
+                        the item's @hidden attribute.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
 
     <xsd:simpleType name="weightType">
         <xsd:annotation>


### PR DESCRIPTION
Adding support for the new changelog element. Relates to https://github.com/scapcommunity/XCCDF/issues/10.